### PR TITLE
Fix a crash while switching to force black background.

### DIFF
--- a/FlyingAndroid/src/jp/tkgktyk/flyingandroid/FlyingHelper.java
+++ b/FlyingAndroid/src/jp/tkgktyk/flyingandroid/FlyingHelper.java
@@ -308,10 +308,11 @@ public class FlyingHelper {
 
 	private void forceSetBlackBackground() {
 		if (mForceSet) {
-			Activity activity = (Activity) mFlyingLayout.getContext();
-			// force set black background for clear background.
-			activity.getWindow().setBackgroundDrawableResource(
-					android.R.drawable.screen_background_dark);
+			Drawable dark = mFlyingLayout.getContext()
+					.getResources()
+					.getDrawable(
+							android.R.drawable.screen_background_dark);
+			mFlyingLayout.setBackgroundDrawable(dark);
 		}
 	}
 


### PR DESCRIPTION
From Nougat, below line is not supported. We can do it in another existing way.
- Activity activity = (Activity) mFlyingLayout.getContext();